### PR TITLE
Ft login resource and endoint 149365455

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+.cache
 .coverage
 .DS_Store
 app/__init__.pyc

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,3 +7,4 @@ app.config.from_object('config')
 db = SQLAlchemy(app)
 
 from . import models
+from . import views

--- a/app/views.py
+++ b/app/views.py
@@ -1,0 +1,25 @@
+from flask_jwt import JWT, jwt_required, current_identity
+from flask_restful import Api, Resource, abort, reqparse
+from app import app, db
+from .models import Bucketlist, Item, User
+
+api = Api(app)
+
+def verify(username, password):
+    if not (username and password):
+        return False
+    else:
+        user = User.query.filter_by(username=username).first()
+        if user:
+            if user.password == password:
+                return user
+        else:
+            return False
+
+
+def identity(payload):
+    user_id = payload['identity']
+    return {"user_id": user_id}
+
+
+jwt = JWT(app, verify, identity)

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
 SECRET_KEY = 'asdfh87sf454yhggfd45dererfds22as112'
 SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/bcktlst'
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+JWT_AUTH_URL_RULE = '/api/v1/auth/login'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -47,10 +47,18 @@ class UserTest(unittest.TestCase):
         response = self.client.post('/api/v1/auth/login', data=json.dumps(user), headers=self.headers)
         self.assertTrue(b'access_token' in response.data)
 
-    def test_wrong_login_credentials_returns_message(self):
+    def test_wrong_login_credentials_returns_correct_message(self):
         user = {
             "username": "john",
             "password": "dorian"
+        }
+        response = self.client.post('/api/v1/auth/login', data=json.dumps(user), headers=self.headers)
+        self.assertTrue(b'Invalid credentials' in response.data)
+
+    def test_empty_submit_returns_correct_message(self):
+        user = {
+            "username": "",
+            "password": ""
         }
         response = self.client.post('/api/v1/auth/login', data=json.dumps(user), headers=self.headers)
         self.assertTrue(b'Invalid credentials' in response.data)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -39,4 +39,12 @@ class UserTest(unittest.TestCase):
         response = self.client.post('/api/v1/auth/login', data=json.dumps(user), headers=self.headers)
         self.assertTrue(response.status_code == 200)
 
+    def test_login_success_response_has_token(self):
+        user = {
+            "username": self.saved_user.username,
+            "password": self.saved_user.password
+        }
+        response = self.client.post('/api/v1/auth/login', data=json.dumps(user), headers=self.headers)
+        self.assertTrue(b'access_token' in response.data)
+
     

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,42 @@
+from app import app, db
+from app.models import User, Bucketlist, Item
+from flask_sqlalchemy import SQLAlchemy
+import unittest
+import json
+
+
+class UserTest(unittest.TestCase):
+    def setUp(self):
+        app.config['SECRET_KEY'] = '8h87yhggfd45dfds22as'
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
+        app.config['DEBUG'] = True
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://localhost/db_for_api_tests'
+        self.client = app.test_client()
+        db.drop_all()
+        db.create_all()
+
+        self.headers = {"Content-Type": "application/json"}
+        self.temp_user = {
+            "username": "Sansa",
+            "email": "sansa@gmail.com",
+            "password": "wicked",
+            "confirm_password": "wicked"
+        }
+
+        self.saved_user = User("tyrion", "tyrion@gmail.com", "lion")
+        db.session.add(self.saved_user)
+        db.session.commit()
+ 
+    def tearDown(self):
+        db.session.remove
+
+    def test_login_returns_ok_status_code(self):
+        user = {
+            "username": self.saved_user.username,
+            "password": self.saved_user.password
+        }
+        response = self.client.post('/api/v1/auth/login', data=json.dumps(user), headers=self.headers)
+        self.assertTrue(response.status_code == 200)
+
+    

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -47,4 +47,12 @@ class UserTest(unittest.TestCase):
         response = self.client.post('/api/v1/auth/login', data=json.dumps(user), headers=self.headers)
         self.assertTrue(b'access_token' in response.data)
 
+    def test_wrong_login_credentials_returns_message(self):
+        user = {
+            "username": "john",
+            "password": "dorian"
+        }
+        response = self.client.post('/api/v1/auth/login', data=json.dumps(user), headers=self.headers)
+        self.assertTrue(b'Invalid credentials' in response.data)
+
     


### PR DESCRIPTION
#### What does this PR do?
Add a login endpoint for the bucket list REST API
#### Description of Task to be completed?
Implement functionality for the endpoint:
- /api/v1/auth/login
When a registered user posts corrent credentials, they should be able to receive a token for their subsequent requests  
#### How should this be manually tested?
A sample user with the credentials, username: "geezluiz" and password: "qwerty" has been created.
- The endpoint can be tested using postman with these credentials
- Alternatively, the request can be invoked on the terminal using
   - curl -H "Content-Type: application/json" -X POST -d '{"username":"geezluiz","password":"qwerty"}' http://localhost:5000/api/v1/auth/login
#### What are the relevant pivotal tracker stories?
#149365455