### PR TITLE
Ft create bucket list endpoint and resource 149365507

### DIFF
--- a/app/resources.py
+++ b/app/resources.py
@@ -89,6 +89,21 @@ class BucketlistResource(Resource):
                     'name': bucketlist.name, 'description': bucketlist.description}
             return bucketlists
 
+    @jwt_required()
+    def post(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument('name', type=str, required=True, location='json')
+        parser.add_argument('description', type=str, required=True, location='json')
+
+        args = parser.parse_args(strict=True)
+        if len(args['name'].strip()) == 0 or len(args['description'].strip()) == 0:
+            return {'message': 'empty strings not allowed'}
+        else:
+            new_bucketlist = Bucketlist(args['name'], args['description'], current_identity['user_id'])
+            db.session.add(new_bucketlist)
+            db.session.commit()
+            return {'message': 'bucketlist created successfully'}
+
 
 api.add_resource(UserResource, '/auth/register')
 api.add_resource(BucketlistResource, '/bucketlists/<int:id>', '/bucketlists')

--- a/app/resources.py
+++ b/app/resources.py
@@ -72,11 +72,14 @@ class BucketlistResource(Resource):
     def get(self, id=None):
         if id is not None:
             bucketlist = Bucketlist.query.get(id)
-            return {
-                'id': bucketlist.id,
-                'name': bucketlist.name,
-                'description': bucketlist.description
-            }
+            if bucketlist is not None:
+                return {
+                    'id': bucketlist.id,
+                    'name': bucketlist.name,
+                    'description': bucketlist.description
+                }
+            else:
+                return {'message': 'requested id does not exist'}
         else:
             result = Bucketlist.query.all()
 

--- a/app/resources.py
+++ b/app/resources.py
@@ -86,24 +86,50 @@ class BucketlistResource(Resource):
             bucketlists = dict()
             for bucketlist in result:
                 bucketlists[bucketlist.id] = {
-                    'name': bucketlist.name, 'description': bucketlist.description}
+                    'name': bucketlist.name,
+                    'description': bucketlist.description
+                }
             return bucketlists
 
     @jwt_required()
     def post(self):
         parser = reqparse.RequestParser()
-        parser.add_argument('name', type=str, required=True, location='json')
-        parser.add_argument('description', type=str, required=True, location='json')
+        parser.add_argument('name',
+                            type=str, required=True, location='json')
+        parser.add_argument('description', type=str,
+                            required=True, location='json')
 
         args = parser.parse_args(strict=True)
-        if len(args['name'].strip()) == 0 or len(args['description'].strip()) == 0:
+        if len(args['name'].strip()) == 0 or len(
+            args['description'].strip()) == 0:
             return {'message': 'empty strings not allowed'}
         else:
-            new_bucketlist = Bucketlist(args['name'], args['description'], current_identity['user_id'])
+            new_bucketlist = Bucketlist(
+                args['name'], args['description'],
+                current_identity['user_id'])
             db.session.add(new_bucketlist)
             db.session.commit()
             return {'message': 'bucketlist created successfully'}
 
+    @jwt_required()
+    def put(self, id):
+        parser = reqparse.RequestParser()
+        parser.add_argument('name',
+                            type=str, required=True, location='json')
+        parser.add_argument('description', type=str,
+                            required=True, location='json')
+
+        args = parser.parse_args(strict=True)
+
+        bucketlist = Bucketlist.query.filter_by(id=id).first()
+        bucketlist.name = args['name']
+        bucketlist.description = args['description']
+
+        db.session.merge(bucketlist)
+        db.session.commit()
+        return {'message': 'bucketlist updated successfully'}
+
 
 api.add_resource(UserResource, '/auth/register')
-api.add_resource(BucketlistResource, '/bucketlists/<int:id>', '/bucketlists')
+api.add_resource(BucketlistResource,
+                 '/bucketlists/<int:id>', '/bucketlists')

--- a/app/resources.py
+++ b/app/resources.py
@@ -101,7 +101,7 @@ class BucketlistResource(Resource):
 
         args = parser.parse_args(strict=True)
         if len(args['name'].strip()) == 0 or len(
-            args['description'].strip()) == 0:
+                args['description'].strip()) == 0:
             return {'message': 'empty strings not allowed'}
         else:
             new_bucketlist = Bucketlist(
@@ -122,12 +122,19 @@ class BucketlistResource(Resource):
         args = parser.parse_args(strict=True)
 
         bucketlist = Bucketlist.query.filter_by(id=id).first()
-        bucketlist.name = args['name']
-        bucketlist.description = args['description']
+        if bucketlist is not None:
+            if len(args['name'].strip()) == 0 or len(
+                    args['description'].strip()) == 0:
+                return {'message': 'empty strings not allowed'}
+            else:
+                bucketlist.name = args['name']
+                bucketlist.description = args['description']
 
-        db.session.merge(bucketlist)
-        db.session.commit()
-        return {'message': 'bucketlist updated successfully'}
+                db.session.merge(bucketlist)
+                db.session.commit()
+                return {'message': 'bucketlist updated successfully'}
+        else:
+            return {'message': 'does not exist'}
 
 
 api.add_resource(UserResource, '/auth/register')

--- a/app/resources.py
+++ b/app/resources.py
@@ -136,6 +136,16 @@ class BucketlistResource(Resource):
         else:
             return {'message': 'does not exist'}
 
+    @jwt_required()
+    def delete(self, id):
+        bucketlist = Bucketlist.query.get(id)
+        if bucketlist is not None:
+            db.session.delete(bucketlist)
+            db.session.commit()
+            return {'message': 'bucketlist deleted successfully'}
+        else:
+            return {'message': 'cannot delete non-existent bucketlist'}
+
 
 api.add_resource(UserResource, '/auth/register')
 api.add_resource(BucketlistResource,

--- a/app/resources.py
+++ b/app/resources.py
@@ -38,7 +38,7 @@ class UserResource(Resource):
         parser = reqparse.RequestParser()
         parser.add_argument('username', type=str,
                             required=True, location='json')
-        parser.add_argument('email', type=str, required=True, 
+        parser.add_argument('email', type=str, required=True,
                             location='json')
         parser.add_argument('password', type=str,
                             required=True, location='json')
@@ -56,7 +56,7 @@ class UserResource(Resource):
                     db.session.commit()
                     return {'message': 'user successfully registered!'}
                 else:
-                    return {'message': 'Make password should match '\
+                    return {'message': 'Make password should match '
                                        'confirm password'}
             else:
                 return {'message': 'email is required'}
@@ -64,4 +64,28 @@ class UserResource(Resource):
             return {'message': 'username is required'}
 
 
+class BucketlistResource(Resource):
+    '''
+    Defines handlers for get, post and put bucketlist requests
+    '''
+    @jwt_required()
+    def get(self, id=None):
+        if id is not None:
+            bucketlist = Bucketlist.query.get(id)
+            return {
+                'id': bucketlist.id,
+                'name': bucketlist.name,
+                'description': bucketlist.description
+            }
+        else:
+            result = Bucketlist.query.all()
+
+            bucketlists = dict()
+            for bucketlist in result:
+                bucketlists[bucketlist.id] = {
+                    'name': bucketlist.name, 'description': bucketlist.description}
+            return bucketlists
+
+
 api.add_resource(UserResource, '/auth/register')
+api.add_resource(BucketlistResource, '/bucketlists/<int:id>', '/bucketlists')

--- a/tests/base_testcase.py
+++ b/tests/base_testcase.py
@@ -2,11 +2,12 @@ import unittest
 from passlib.hash import bcrypt
 
 from app import app, db
-from app.models import User
+from app.models import User, Bucketlist
 
 
 class BaseTest(unittest.TestCase):
     def setUp(self):
+        #setup test environment configuration
         app.config['SECRET_KEY'] = '8h87yhggfd45dfds22as'
         app.config['TESTING'] = True
         app.config['WTF_CSRF_ENABLED'] = False
@@ -18,6 +19,7 @@ class BaseTest(unittest.TestCase):
         db.create_all()
 
         self.headers = {"Content-Type": "application/json"}
+        #define a user to be used for registration tests
         self.temp_user = {
             "username": "Sansa",
             "email": "sansa@gmail.com",
@@ -25,10 +27,11 @@ class BaseTest(unittest.TestCase):
             "confirm_password": "wicked"
         }
 
+        #define an existing user
         self.saved_user = User("tyrion", "tyrion@gmail.com",
                                bcrypt.hash("lion", rounds=12))
         db.session.add(self.saved_user)
-        db.session.commit()
+        db.session.commit()        
 
     def tearDown(self):
         db.session.remove

--- a/tests/base_testcase.py
+++ b/tests/base_testcase.py
@@ -1,0 +1,35 @@
+import unittest
+from passlib.hash import bcrypt
+
+from app import app, db
+from app.models import User
+
+
+class BaseTest(unittest.TestCase):
+    def setUp(self):
+        app.config['SECRET_KEY'] = '8h87yhggfd45dfds22as'
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
+        app.config['DEBUG'] = True
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://'\
+            'localhost/db_for_api_tests'
+        self.client = app.test_client()
+        db.drop_all()
+        db.create_all()
+
+        self.headers = {"Content-Type": "application/json"}
+        self.temp_user = {
+            "username": "Sansa",
+            "email": "sansa@gmail.com",
+            "password": "wicked",
+            "confirm_password": "wicked"
+        }
+
+        self.saved_user = User("tyrion", "tyrion@gmail.com",
+                               bcrypt.hash("lion", rounds=12))
+        db.session.add(self.saved_user)
+        db.session.commit()
+
+    def tearDown(self):
+        db.session.remove
+        db.drop_all()

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -47,14 +47,13 @@ class BucketlistResourceTest(BaseTest):
     def tearDown(self):
         super(BucketlistResourceTest, self).tearDown()
 
+    #view bucketlists tests
     def test_view_bucketlists_status_code_is_ok(self):
-        
         response = self.client.get(
             '/api/v1/bucketlists', data=json.dumps(self.user),
             headers=self.headers)
         self.assertEqual(response.status_code, 200)
-    
-    
+
     def test_if_bucketlist_name_is_returned(self):
         response = self.client.get(
             '/api/v1/bucketlists', data=json.dumps(self.user),
@@ -88,7 +87,7 @@ class BucketlistResourceTest(BaseTest):
             '/api/v1/bucketlists/{}'.format(self.bucketlist_one_id),
             data=json.dumps(self.user),
             headers=self.headers)
-        
+
         self.assertTrue(b'bucketlist_one' in response.data)
 
     def test_only_one_bucketlist_is_returned_given_id(self):
@@ -96,7 +95,7 @@ class BucketlistResourceTest(BaseTest):
             '/api/v1/bucketlists/{}'.format(self.bucketlist_one_id),
             data=json.dumps(self.user),
             headers=self.headers)
-        
+
         self.assertEqual(response.data.count(b'id'), 1)
 
     def test_response_message_for_non_existent_id(self):
@@ -106,6 +105,7 @@ class BucketlistResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(b'requested id does not exist' in response.data)
 
+    #create bucketlist tests
     def test_bucketlist_created_successfully_message(self):
         new_bucketlist = {
             "name": "new bucketlist",
@@ -151,19 +151,41 @@ class BucketlistResourceTest(BaseTest):
             headers=no_token)
         self.assertTrue(b'Authorization Required' in response.data)
 
+    #Update bucketlists tests
     def test_bucketlist_successfully_updated_message(self):
         updates = {
             "name": "the first one",
             "description": "there will be another"
         }
         response = self.client.put(
-            '/api/v1/bucketlists/{}'.format(self.example_bucketlist_one.id),
+            '/api/v1/bucketlists/{}'.format(
+                self.example_bucketlist_one.id),
             data=json.dumps(updates),
             headers=self.headers)
-        self.assertTrue(b'bucketlist updated successfully' in response.data)
+        self.assertTrue(b'bucketlist updated successfully'
+                        in response.data)
 
+    def test_message_bucketlist_id_does_not_exist(self):
+        updates = {
+            "name": "the first one",
+            "description": "there will be another"
+        }
+        response = self.client.put(
+            '/api/v1/bucketlists/{}'.format(89),
+            data=json.dumps(updates),
+            headers=self.headers)
+        self.assertTrue(b'does not exist' in response.data)
 
+    def test_update_bucketlist_request_with_empty_strings(self):
+        updates = {
+            "name": "",
+            "description": "this has no name"
+        }
+        response = self.client.put(
+            '/api/v1/bucketlists/{}'.format(
+                self.example_bucketlist_one.id),
+            data=json.dumps(updates),
+            headers=self.headers)
+        self.assertTrue(b'empty strings not allowed' in response.data)
 
-
-
-        
+    #delete bucketlist tests

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -1,0 +1,33 @@
+from flask_sqlalchemy import SQLAlchemy
+import unittest
+import json
+from passlib.hash import bcrypt
+
+from app import app, db
+from app.models import User, Bucketlist
+from base_testcase import BaseTest
+
+
+class BucketlistResourceTest(BaseTest):
+    def setUp(self):
+        super(BucketlistResourceTest, self).setUp()
+
+    def tearDown(self):
+        super(BucketlistResourceTest, self).tearDown()
+
+    def test_view_bucketlists_status_code_is_ok(self):
+        user = {
+            "username": self.saved_user.username,
+            "password": "lion"
+        }
+        response = self.client.post(
+            '/api/v1/auth/login', data=json.dumps(user),
+            headers=self.headers)
+        response_content = json.loads(response.data)
+        #print(response_content['access_token'])
+        self.headers['Authorization'] = 'JWT {}'.format(response_content['access_token'])
+        print('JWT {}'.format(self.headers))
+        response = self.client.post(
+            '/api/v1/bucketlists', data=json.dumps(user),
+            headers=self.headers)
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -34,6 +34,9 @@ class BucketlistResourceTest(BaseTest):
         db.session.add(self.example_bucketlist_two)
         db.session.commit()
 
+        self.bucketlist_one_id = Bucketlist.query.filter_by(
+            name="bucketlist_one").first().id
+
     def tearDown(self):
         super(BucketlistResourceTest, self).tearDown()
 
@@ -79,3 +82,59 @@ class BucketlistResourceTest(BaseTest):
             '/api/v1/bucketlists', data=json.dumps(self.user),
             headers=self.headers)
         self.assertTrue(b'Authorization Required' in response.data)
+
+    def test_successful_status_code_when_bucket_id_is_specified(self):
+        response = self.client.post(
+            '/api/v1/auth/login', data=json.dumps(self.user),
+            headers=self.headers)
+        response_content = json.loads(response.data)
+        self.headers['Authorization'] = 'JWT {}'.format(
+            response_content['access_token'])
+        response = self.client.get(
+            '/api/v1/bucketlists/{}'.format(self.bucketlist_one_id),
+            data=json.dumps(self.user),
+            headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+
+    def test_bucketlist_name_is_returned_given_id(self):
+        response = self.client.post(
+            '/api/v1/auth/login', data=json.dumps(self.user),
+            headers=self.headers)
+        response_content = json.loads(response.data)
+        self.headers['Authorization'] = 'JWT {}'.format(
+            response_content['access_token'])
+        response = self.client.get(
+            '/api/v1/bucketlists/{}'.format(self.bucketlist_one_id),
+            data=json.dumps(self.user),
+            headers=self.headers)
+        
+        self.assertTrue(b'bucketlist_one' in response.data)
+
+    def test_only_one_bucketlist_is_returned_given_id(self):
+        response = self.client.post(
+            '/api/v1/auth/login', data=json.dumps(self.user),
+            headers=self.headers)
+        response_content = json.loads(response.data)
+        self.headers['Authorization'] = 'JWT {}'.format(
+            response_content['access_token'])
+        response = self.client.get(
+            '/api/v1/bucketlists/{}'.format(self.bucketlist_one_id),
+            data=json.dumps(self.user),
+            headers=self.headers)
+        
+        self.assertEqual(response.data.count(b'id'), 1)
+
+    def test_response_message_for_non_existent_id(self):
+        response = self.client.post(
+            '/api/v1/auth/login', data=json.dumps(self.user),
+            headers=self.headers)
+        response_content = json.loads(response.data)
+        self.headers['Authorization'] = 'JWT {}'.format(
+            response_content['access_token'])
+        response = self.client.get(
+            '/api/v1/bucketlists/2000',
+            data=json.dumps(self.user),
+            headers=self.headers)
+        self.assertTrue(b'requested id does not exist' in response.data)
+
+        

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -151,6 +151,18 @@ class BucketlistResourceTest(BaseTest):
             headers=no_token)
         self.assertTrue(b'Authorization Required' in response.data)
 
+    def test_bucketlist_successfully_updated_message(self):
+        updates = {
+            "name": "the first one",
+            "description": "there will be another"
+        }
+        response = self.client.put(
+            '/api/v1/bucketlists/{}'.format(self.example_bucketlist_one.id),
+            data=json.dumps(updates),
+            headers=self.headers)
+        self.assertTrue(b'bucketlist updated successfully' in response.data)
+
+
 
 
 

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -37,40 +37,31 @@ class BucketlistResourceTest(BaseTest):
         self.bucketlist_one_id = Bucketlist.query.filter_by(
             name="bucketlist_one").first().id
 
+        self.response = self.client.post(
+            '/api/v1/auth/login', data=json.dumps(self.user),
+            headers=self.headers)
+        self.response_content = json.loads(self.response.data)
+        self.headers['Authorization'] = 'JWT {}'.format(
+            self.response_content['access_token'])
+
     def tearDown(self):
         super(BucketlistResourceTest, self).tearDown()
 
     def test_view_bucketlists_status_code_is_ok(self):
-        response = self.client.post(
-            '/api/v1/auth/login', data=json.dumps(self.user),
-            headers=self.headers)
-        response_content = json.loads(response.data)
-        self.headers['Authorization'] = 'JWT {}'.format(
-            response_content['access_token'])
+        
         response = self.client.get(
             '/api/v1/bucketlists', data=json.dumps(self.user),
             headers=self.headers)
         self.assertEqual(response.status_code, 200)
-
+    
+    
     def test_if_bucketlist_name_is_returned(self):
-        response = self.client.post(
-            '/api/v1/auth/login', data=json.dumps(self.user),
-            headers=self.headers)
-        response_content = json.loads(response.data)
-        self.headers['Authorization'] = 'JWT {}'.format(
-            response_content['access_token'])
         response = self.client.get(
             '/api/v1/bucketlists', data=json.dumps(self.user),
             headers=self.headers)
         self.assertTrue(b'bucketlist_one' in response.data)
 
     def test_all_bucketlists_are_returned(self):
-        response = self.client.post(
-            '/api/v1/auth/login', data=json.dumps(self.user),
-            headers=self.headers)
-        response_content = json.loads(response.data)
-        self.headers['Authorization'] = 'JWT {}'.format(
-            response_content['access_token'])
         response = self.client.get(
             '/api/v1/bucketlists', data=json.dumps(self.user),
             headers=self.headers)
@@ -78,18 +69,14 @@ class BucketlistResourceTest(BaseTest):
                         and b'bucketlist_two' in response.data)
 
     def test_cant_view_bucketlists_without_token(self):
+        no_token = self.headers
+        no_token['Authorization'] = ""
         response = self.client.get(
             '/api/v1/bucketlists', data=json.dumps(self.user),
-            headers=self.headers)
+            headers=no_token)
         self.assertTrue(b'Authorization Required' in response.data)
 
     def test_successful_status_code_when_bucket_id_is_specified(self):
-        response = self.client.post(
-            '/api/v1/auth/login', data=json.dumps(self.user),
-            headers=self.headers)
-        response_content = json.loads(response.data)
-        self.headers['Authorization'] = 'JWT {}'.format(
-            response_content['access_token'])
         response = self.client.get(
             '/api/v1/bucketlists/{}'.format(self.bucketlist_one_id),
             data=json.dumps(self.user),
@@ -97,12 +84,6 @@ class BucketlistResourceTest(BaseTest):
         self.assertEqual(response.status_code, 200)
 
     def test_bucketlist_name_is_returned_given_id(self):
-        response = self.client.post(
-            '/api/v1/auth/login', data=json.dumps(self.user),
-            headers=self.headers)
-        response_content = json.loads(response.data)
-        self.headers['Authorization'] = 'JWT {}'.format(
-            response_content['access_token'])
         response = self.client.get(
             '/api/v1/bucketlists/{}'.format(self.bucketlist_one_id),
             data=json.dumps(self.user),
@@ -111,12 +92,6 @@ class BucketlistResourceTest(BaseTest):
         self.assertTrue(b'bucketlist_one' in response.data)
 
     def test_only_one_bucketlist_is_returned_given_id(self):
-        response = self.client.post(
-            '/api/v1/auth/login', data=json.dumps(self.user),
-            headers=self.headers)
-        response_content = json.loads(response.data)
-        self.headers['Authorization'] = 'JWT {}'.format(
-            response_content['access_token'])
         response = self.client.get(
             '/api/v1/bucketlists/{}'.format(self.bucketlist_one_id),
             data=json.dumps(self.user),
@@ -125,16 +100,33 @@ class BucketlistResourceTest(BaseTest):
         self.assertEqual(response.data.count(b'id'), 1)
 
     def test_response_message_for_non_existent_id(self):
-        response = self.client.post(
-            '/api/v1/auth/login', data=json.dumps(self.user),
-            headers=self.headers)
-        response_content = json.loads(response.data)
-        self.headers['Authorization'] = 'JWT {}'.format(
-            response_content['access_token'])
         response = self.client.get(
             '/api/v1/bucketlists/2000',
             data=json.dumps(self.user),
             headers=self.headers)
         self.assertTrue(b'requested id does not exist' in response.data)
+
+    def test_bucketlist_created_successfully_message(self):
+        new_bucketlist = {
+            "name": "new bucketlist",
+            "description": "this is a test bucketlist"
+        }
+        response = self.client.post(
+            '/api/v1/bucketlists',
+            data=json.dumps(new_bucketlist),
+            headers=self.headers)
+        self.assertTrue(b'bucketlist created successfully' in response.data)
+
+    def test_create_bucketlist_request_missing_field_message(self):
+        new_bucketlist = {
+            "name": "new bucketlist"
+        }
+        response = self.client.post(
+            '/api/v1/bucketlists',
+            data=json.dumps(new_bucketlist),
+            headers=self.headers)
+        self.assertTrue(b'Missing required parameter' in response.data)
+
+
 
         

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -127,6 +127,31 @@ class BucketlistResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(b'Missing required parameter' in response.data)
 
+    def test_create_bucketlist_request_with_empty_strings(self):
+        new_bucketlist = {
+            "name": "",
+            "description": "this has no name"
+        }
+        response = self.client.post(
+            '/api/v1/bucketlists',
+            data=json.dumps(new_bucketlist),
+            headers=self.headers)
+        self.assertTrue(b'empty strings not allowed' in response.data)
+
+    def test_cant_create_bucketlist_without_authentication(self):
+        new_bucketlist = {
+            "name": "Not allowed",
+            "description": "I have not been authenticated!"
+        }
+        no_token = self.headers
+        no_token['Authorization'] = ""
+        response = self.client.post(
+            '/api/v1/bucketlists',
+            data=json.dumps(new_bucketlist),
+            headers=no_token)
+        self.assertTrue(b'Authorization Required' in response.data)
+
+
 
 
         

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -11,23 +11,71 @@ from base_testcase import BaseTest
 class BucketlistResourceTest(BaseTest):
     def setUp(self):
         super(BucketlistResourceTest, self).setUp()
+        self.user = {
+            "username": self.saved_user.username,
+            "password": "lion"
+        }
+
+        # create a bucketlist for tyrion
+        current_user = User.query.filter_by(
+            username=self.saved_user.username).first()
+        self.example_bucketlist_one = Bucketlist(
+            "bucketlist_one",
+            "this is an example bucketlist",
+            current_user.id)
+        db.session.add(self.example_bucketlist_one)
+        db.session.commit()
+
+        # create a second bucketlist for tyrion
+        self.example_bucketlist_two = Bucketlist(
+            "bucketlist_two",
+            "this is an another bucketlist",
+            current_user.id)
+        db.session.add(self.example_bucketlist_two)
+        db.session.commit()
 
     def tearDown(self):
         super(BucketlistResourceTest, self).tearDown()
 
     def test_view_bucketlists_status_code_is_ok(self):
-        user = {
-            "username": self.saved_user.username,
-            "password": "lion"
-        }
         response = self.client.post(
-            '/api/v1/auth/login', data=json.dumps(user),
+            '/api/v1/auth/login', data=json.dumps(self.user),
             headers=self.headers)
         response_content = json.loads(response.data)
-        #print(response_content['access_token'])
-        self.headers['Authorization'] = 'JWT {}'.format(response_content['access_token'])
-        print('JWT {}'.format(self.headers))
-        response = self.client.post(
-            '/api/v1/bucketlists', data=json.dumps(user),
+        self.headers['Authorization'] = 'JWT {}'.format(
+            response_content['access_token'])
+        response = self.client.get(
+            '/api/v1/bucketlists', data=json.dumps(self.user),
             headers=self.headers)
         self.assertEqual(response.status_code, 200)
+
+    def test_if_bucketlist_name_is_returned(self):
+        response = self.client.post(
+            '/api/v1/auth/login', data=json.dumps(self.user),
+            headers=self.headers)
+        response_content = json.loads(response.data)
+        self.headers['Authorization'] = 'JWT {}'.format(
+            response_content['access_token'])
+        response = self.client.get(
+            '/api/v1/bucketlists', data=json.dumps(self.user),
+            headers=self.headers)
+        self.assertTrue(b'bucketlist_one' in response.data)
+
+    def test_all_bucketlists_are_returned(self):
+        response = self.client.post(
+            '/api/v1/auth/login', data=json.dumps(self.user),
+            headers=self.headers)
+        response_content = json.loads(response.data)
+        self.headers['Authorization'] = 'JWT {}'.format(
+            response_content['access_token'])
+        response = self.client.get(
+            '/api/v1/bucketlists', data=json.dumps(self.user),
+            headers=self.headers)
+        self.assertTrue(b'bucketlist_one' in response.data
+                        and b'bucketlist_two' in response.data)
+
+    def test_cant_view_bucketlists_without_token(self):
+        response = self.client.get(
+            '/api/v1/bucketlists', data=json.dumps(self.user),
+            headers=self.headers)
+        self.assertTrue(b'Authorization Required' in response.data)

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -47,7 +47,7 @@ class BucketlistResourceTest(BaseTest):
     def tearDown(self):
         super(BucketlistResourceTest, self).tearDown()
 
-    #view bucketlists tests
+    # view bucketlists tests
     def test_view_bucketlists_status_code_is_ok(self):
         response = self.client.get(
             '/api/v1/bucketlists', data=json.dumps(self.user),
@@ -105,7 +105,7 @@ class BucketlistResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(b'requested id does not exist' in response.data)
 
-    #create bucketlist tests
+    # create bucketlist tests
     def test_bucketlist_created_successfully_message(self):
         new_bucketlist = {
             "name": "new bucketlist",
@@ -151,7 +151,7 @@ class BucketlistResourceTest(BaseTest):
             headers=no_token)
         self.assertTrue(b'Authorization Required' in response.data)
 
-    #Update bucketlists tests
+    # Update bucketlists tests
     def test_bucketlist_successfully_updated_message(self):
         updates = {
             "name": "the first one",
@@ -188,4 +188,19 @@ class BucketlistResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(b'empty strings not allowed' in response.data)
 
-    #delete bucketlist tests
+    # delete bucketlist tests
+    def test_bucketlist_deleted_successfully_message(self):
+        response = self.client.delete(
+            '/api/v1/bucketlists/{}'.format(
+                self.example_bucketlist_one.id),
+            data={},
+            headers=self.headers)
+        self.assertTrue(b'bucketlist deleted successfully'
+                        in response.data)
+
+    def test_message_for_invalid_bucketlist_id(self):
+        response = self.client.delete(
+            '/api/v1/bucketlists/{}'.format(21), data={},
+            headers=self.headers)
+        self.assertTrue(
+            b'cannot delete non-existent bucketlist' in response.data)

--- a/tests/test_user_resource.py
+++ b/tests/test_user_resource.py
@@ -15,6 +15,7 @@ class UserResourceTest(BaseTest):
     def tearDown(self):
         super(UserResourceTest, self).tearDown()
 
+    #user login tests
     def test_login_returns_ok_status_code(self):
         user = {
             "username": self.saved_user.username,
@@ -45,7 +46,7 @@ class UserResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(b'Invalid credentials' in response.data)
 
-    def test_empty_submit_returns_correct_message(self):
+    def test_login_with_empty_submit_returns_correct_message(self):
         user = {
             "username": "",
             "password": ""
@@ -55,6 +56,7 @@ class UserResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(b'Invalid credentials' in response.data)
 
+    #user register tests
     def test_register_returns_ok_status_code(self):
         user = self.temp_user
         response = self.client.post(

--- a/tests/test_user_resource.py
+++ b/tests/test_user_resource.py
@@ -4,37 +4,16 @@ import json
 from passlib.hash import bcrypt
 
 from app import app, db
-from app.models import User, Bucketlist, Item
+from app.models import User
+from base_testcase import BaseTest
 
 
-class UserTest(unittest.TestCase):
+class UserResourceTest(BaseTest):
     def setUp(self):
-        app.config['SECRET_KEY'] = '8h87yhggfd45dfds22as'
-        app.config['TESTING'] = True
-        app.config['WTF_CSRF_ENABLED'] = False
-        app.config['DEBUG'] = True
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://'\
-            'localhost/db_for_api_tests'
-        self.client = app.test_client()
-        db.drop_all()
-        db.create_all()
-
-        self.headers = {"Content-Type": "application/json"}
-        self.temp_user = {
-            "username": "Sansa",
-            "email": "sansa@gmail.com",
-            "password": "wicked",
-            "confirm_password": "wicked"
-        }
-
-        self.saved_user = User("tyrion", "tyrion@gmail.com",
-                               bcrypt.hash("lion", rounds=12))
-        db.session.add(self.saved_user)
-        db.session.commit()
+        super(UserResourceTest, self).setUp()
 
     def tearDown(self):
-        db.session.remove
-        db.drop_all()
+        super(UserResourceTest, self).tearDown()
 
     def test_login_returns_ok_status_code(self):
         user = {


### PR DESCRIPTION
#### What does this PR do?
Add view, create, update and delete features to the bucketlist API 
#### Description of Task to be completed?
Implement functionality for the endpoint:
- /api/v1/bucketlists
- /api/v1/bucketlists/<int:id>
For the get, post, put and delete requests
An authenticated user should be able to:
- Create a new bucketlist by providing a name and description
- View existing bucketlists
- Update the name and description of a bucketlist with valid text
#### How should this be manually tested?
- The API endpoints can be tested using Postman or curl via the Terminal
- e.g for a get request on the /api/v1/bucketlists endpoint:
        - start the server locally by running; python run.py in the terminal
        - login with valid credentials to receive an authentication token
        - in a new tab set the request type to GET
        - enter the endpoint url in the Postman url field as: http://127.0.0.1:5000/api/v1/bucketlists
        - input the token received from login into the header with the key as Authorization. The token should be prefixed with "JWT "
- click on the GET button to send the request
        - you should receive a response with all the existing bucketlists or an empty response if there's no bucketlist
#### What are the relevant pivotal tracker stories?
#149365619
#149365507
#149365775