### PR TITLE
Ft create bucket list item endpoint and resource 149365789

### DIFF
--- a/app/resources.py
+++ b/app/resources.py
@@ -122,7 +122,7 @@ class BucketlistResource(Resource):
         args = parser.parse_args(strict=True)
 
         bucketlist = Bucketlist.query.filter_by(id=id).first()
-        if bucketlist is not None:
+        if bucketlist:
             if len(args['name'].strip()) == 0 or len(
                     args['description'].strip()) == 0:
                 return {'message': 'empty strings not allowed'}
@@ -159,9 +159,12 @@ class ItemResource(Resource):
             if item_id is not None:
                 item = Item.query.filter_by(bucket_id=id,
                                             id=item_id).first()
-                return {'id': item.id,
-                        'title': item.title,
-                        'description': item.description}
+                if item:
+                    return {'id': item.id,
+                            'title': item.title,
+                            'description': item.description}
+                else:
+                    return {'message': 'item does not exist'}
             else:
                 result = Item.query.filter_by(bucket_id=id).all()
 
@@ -172,6 +175,18 @@ class ItemResource(Resource):
                 return items
         else:
             return {'message': 'bucketlist does not exist'}
+
+    @jwt_required()
+    def post(self, id):
+        parser = reqparse.RequestParser()
+        parser.add_argument('title', type=str, required=True, location='json')
+        parser.add_argument('description', type=str, required=True, location='json')
+
+        args = parser.parse_args(strict=True)
+        new_item = Item(args['title'], args['description'], id)
+        db.session.add(new_item)
+        db.session.commit()
+        return {'message': 'item created successfully'}
         
 
 

--- a/app/resources.py
+++ b/app/resources.py
@@ -153,20 +153,26 @@ class ItemResource(Resource):
     '''
     @jwt_required()
     def get(self, id, item_id=None):
-        if item_id is not None:
-            item = Item.query.filter_by(bucket_id=id,
-                                        id=item_id).first()
-            return {'id': item.id,
-                    'title': item.title,
-                    'description': item.description}
-        else:
-            result = Item.query.filter_by(bucket_id=id).all()
+        bucketlist = Bucketlist.query.get(id)
+        print(bucketlist)
+        if bucketlist is not None:
+            if item_id is not None:
+                item = Item.query.filter_by(bucket_id=id,
+                                            id=item_id).first()
+                return {'id': item.id,
+                        'title': item.title,
+                        'description': item.description}
+            else:
+                result = Item.query.filter_by(bucket_id=id).all()
 
-            items = dict()
-            for item in result:
-                items[item.id] = {'title': item.title,
-                                  'description': item.description}
-            return items
+                items = dict()
+                for item in result:
+                    items[item.id] = {'title': item.title,
+                                    'description': item.description}
+                return items
+        else:
+            return {'message': 'bucketlist does not exist'}
+        
 
 
 api.add_resource(UserResource, '/auth/register')

--- a/app/resources.py
+++ b/app/resources.py
@@ -183,10 +183,14 @@ class ItemResource(Resource):
         parser.add_argument('description', type=str, required=True, location='json')
 
         args = parser.parse_args(strict=True)
-        new_item = Item(args['title'], args['description'], id)
-        db.session.add(new_item)
-        db.session.commit()
-        return {'message': 'item created successfully'}
+        if len(args['title'].strip()) == 0 or len(
+                    args['description'].strip()) == 0:
+                return {'message': 'empty strings not allowed'}
+        else:
+            new_item = Item(args['title'], args['description'], id)
+            db.session.add(new_item)
+            db.session.commit()
+            return {'message': 'item created successfully'}
         
 
 

--- a/app/resources.py
+++ b/app/resources.py
@@ -191,6 +191,39 @@ class ItemResource(Resource):
             db.session.add(new_item)
             db.session.commit()
             return {'message': 'item created successfully'}
+
+    @jwt_required()
+    def put(self, id, item_id):        
+        parser = reqparse.RequestParser()
+        parser.add_argument('title', type=str, required=True, location='json')
+        parser.add_argument('description', type=str, required=True, location='json')
+
+        args = parser.parse_args(strict=True)
+
+        item = Item.query.filter_by(id=item_id, bucket_id=id).first()
+        if item:
+            if len(args['title'].strip()) == 0 or len(
+                    args['description'].strip()) == 0:
+                return {'message': 'empty strings not allowed'}
+            else:
+                item.title = args['title']
+                item.description = args['description']
+        else:
+            return {'message': 'item does not exist'}
+
+        db.session.merge(item)
+        db.session.commit()
+        return {'message': 'item updated successfully'}
+
+    @jwt_required()
+    def delete(self, id, item_id):
+        item = Item.query.filter_by(id=item_id, bucket_id=id).first()
+        if item:
+            db.session.delete(item)
+            db.session.commit()
+            return {'message': 'item deleted successfully'}
+        else: 
+            return {'message': 'cannot delete, item does not exist'}
         
 
 

--- a/app/resources.py
+++ b/app/resources.py
@@ -147,6 +147,31 @@ class BucketlistResource(Resource):
             return {'message': 'cannot delete non-existent bucketlist'}
 
 
+class ItemResource(Resource):
+    '''
+    handles get, post, put and delete item requests
+    '''
+    @jwt_required()
+    def get(self, id, item_id=None):
+        if item_id is not None:
+            item = Item.query.filter_by(bucket_id=id,
+                                        id=item_id).first()
+            return {'id': item.id,
+                    'title': item.title,
+                    'description': item.description}
+        else:
+            result = Item.query.filter_by(bucket_id=id).all()
+
+            items = dict()
+            for item in result:
+                items[item.id] = {'title': item.title,
+                                  'description': item.description}
+            return items
+
+
 api.add_resource(UserResource, '/auth/register')
 api.add_resource(BucketlistResource,
                  '/bucketlists/<int:id>', '/bucketlists')
+api.add_resource(ItemResource,
+                 '/bucketlists/<int:id>/items/<item_id>',
+                 '/bucketlists/<int:id>/items')

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -15,7 +15,7 @@ class BucketlistResourceTest(BaseTest):
             "username": self.saved_user.username,
             "password": "lion"
         }
-
+        
         # create a bucketlist for tyrion
         current_user = User.query.filter_by(
             username=self.saved_user.username).first()
@@ -75,6 +75,7 @@ class BucketlistResourceTest(BaseTest):
             headers=no_token)
         self.assertTrue(b'Authorization Required' in response.data)
 
+    #view specific bucketlist
     def test_successful_status_code_when_bucket_id_is_specified(self):
         response = self.client.get(
             '/api/v1/bucketlists/{}'.format(self.bucketlist_one_id),

--- a/tests/test_bucketlist_resource.py
+++ b/tests/test_bucketlist_resource.py
@@ -53,7 +53,7 @@ class BucketlistResourceTest(BaseTest):
             '/api/v1/bucketlists', data=json.dumps(self.user),
             headers=self.headers)
         self.assertEqual(response.status_code, 200)
-
+    
     def test_if_bucketlist_name_is_returned(self):
         response = self.client.get(
             '/api/v1/bucketlists', data=json.dumps(self.user),
@@ -205,3 +205,4 @@ class BucketlistResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(
             b'cannot delete non-existent bucketlist' in response.data)
+    

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -114,4 +114,16 @@ class ItemResourceTest(BaseTest):
             headers=self.headers)
         print(response.data)
         self.assertTrue(b'Missing required parameter' in response.data)
+
+    def test_create_item_with_empty_strings(self):
+        new_item = {
+            "title": "",
+            "description": "this is my first title"
+        }
+        response = self.client.post(
+            '/api/v1/bucketlists/{}/items'.format(self.item_one_id),
+            data=json.dumps(new_item),
+            headers=self.headers)
+        print(response.data)
+        self.assertTrue(b'empty strings not allowed' in response.data)
         

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -7,6 +7,7 @@ from app import app, db
 from app.models import User, Bucketlist, Item
 from base_testcase import BaseTest
 
+
 class ItemResourceTest(BaseTest):
     def setUp(self):
         super(ItemResourceTest, self).setUp()
@@ -20,7 +21,7 @@ class ItemResourceTest(BaseTest):
             username=self.saved_user.username).first()
         self.example_bucketlist_one = Bucketlist(
             "bucketlist with items",
-            "this is bucketlist has itesm",
+            "this is bucketlist has items",
             current_user.id)
         db.session.add(self.example_bucketlist_one)
         db.session.commit()
@@ -28,9 +29,12 @@ class ItemResourceTest(BaseTest):
         self.bucketlist_with_items_id = Bucketlist.query.filter_by(
             name="bucketlist with items").first().id
 
-        self.item_1 = Item('Item one', 'this is ietm one', self.bucketlist_with_items_id)
-        self.item_2 = Item('Item two', 'this is ietm two', self.bucketlist_with_items_id)
-        db.session.flush()
+        self.item_1 = Item('Item one', 'this is item one',
+                           self.bucketlist_with_items_id)
+        self.item_2 = Item('Item two', 'this is item two',
+                           self.bucketlist_with_items_id)
+        db.session.add(self.item_1)
+        db.session.add(self.item_2)
         db.session.commit()
 
         self.response = self.client.post(
@@ -40,12 +44,25 @@ class ItemResourceTest(BaseTest):
         self.headers['Authorization'] = 'JWT {}'.format(
             self.response_content['access_token'])
 
+    def tearDown(self):
+        super(ItemResourceTest, self).tearDown()
 
     def test_item_names_returned_by_view_bucketlists(self):
         response = self.client.get(
-            '/api/v1/bucketlists/{}/items'.format(self.bucketlist_with_items_id), 
-            data={},
+            '/api/v1/bucketlists/{}/items'.format(
+                self.bucketlist_with_items_id),
             headers=self.headers)
+        print(response.data)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(b'Item one' in response.data)
         self.assertTrue(b'Item two' in response.data)
+
+    def test_cannot_view_items_without_token(self):
+        no_token = self.headers
+        no_token['Authorization'] = ""
+        response = self.client.get(
+            '/api/v1/bucketlists/{}/items'.format(
+                self.bucketlist_with_items_id),
+            data=json.dumps(self.user),
+            headers=no_token)
+        self.assertTrue(b'Authorization Required' in response.data)

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -184,6 +184,13 @@ class ItemResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(b'item deleted successfully' in response.data)
 
+    def test_message_for_delete_non_existing_id(self):
+        response = self.client.delete(
+            '/api/v1/bucketlists/{}/items/{}'.format(
+                self.bucketlist_with_items_id, 40000),
+            headers=self.headers)
+        self.assertTrue(b'item does not exist' in response.data)
+
     
 
         

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -29,6 +29,8 @@ class ItemResourceTest(BaseTest):
         self.bucketlist_with_items_id = Bucketlist.query.filter_by(
             name="bucketlist with items").first().id
 
+        
+
         self.item_1 = Item('Item one', 'this is item one',
                            self.bucketlist_with_items_id)
         self.item_2 = Item('Item two', 'this is item two',
@@ -36,6 +38,8 @@ class ItemResourceTest(BaseTest):
         db.session.add(self.item_1)
         db.session.add(self.item_2)
         db.session.commit()
+
+        self.item_one_id = Item.query.filter_by(title='Item one').first().id
 
         self.response = self.client.post(
             '/api/v1/auth/login', data=json.dumps(self.user),
@@ -71,3 +75,43 @@ class ItemResourceTest(BaseTest):
             headers=self.headers)
         print(response.data)
         self.assertTrue(b'bucketlist does not exist' in response.data)
+
+    def test_item_name_returned_when_item_id_is_specified(self):
+        response = self.client.get(
+            '/api/v1/bucketlists/{}/items/{}'.format(
+                self.bucketlist_with_items_id, self.item_one_id),
+            headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(b'Item one' in response.data)
+
+    def test_message_if_item_id_does_not_exist(self):
+        response = self.client.get(
+            '/api/v1/bucketlists/{}/items/{}'.format(
+                self.bucketlist_with_items_id, 555),
+            headers=self.headers)
+        self.assertTrue(b'item does not exist' in response.data)
+
+    #test create item
+    def test_item_created_successfully_message(self):
+        new_item = {
+            "title": "title one",
+            "description": "this is my first title"
+        }
+        response = self.client.post(
+            '/api/v1/bucketlists/{}/items'.format(self.item_one_id),
+            data=json.dumps(new_item),
+            headers=self.headers)
+        print(response.data)
+        self.assertTrue(b'item created successfully' in response.data)
+
+    def test_create_item_request_missing_field_message(self):
+        new_item = {
+            "description": "this is my first title"
+        }
+        response = self.client.post(
+            '/api/v1/bucketlists/{}/items'.format(self.item_one_id),
+            data=json.dumps(new_item),
+            headers=self.headers)
+        print(response.data)
+        self.assertTrue(b'Missing required parameter' in response.data)
+        

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -151,4 +151,16 @@ class ItemResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(b'item updated successfully' in response.data)
 
+    def test_message_on_update_with_missing_parameter(self):
+        updates = {
+            "description": "descriptive"
+        }
+        response = self.client.put(
+            '/api/v1/bucketlists/{}/items/{}'.format(self.bucketlist_with_items_id, self.item_one_id),
+            data=json.dumps(updates),
+            headers=self.headers)
+        self.assertTrue(b'Missing required parameter' in response.data)
+
+    
+
         

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -139,4 +139,16 @@ class ItemResourceTest(BaseTest):
             data=json.dumps(new_item),
             headers=no_token)
         self.assertTrue(b'Authorization Required' in response.data)
+
+    def test_item_updated_successfully_message(self):
+        updates = {
+            "title": "not item one anymore",
+            "description": "this was changed"
+        }
+        response = self.client.put(
+            '/api/v1/bucketlists/{}/items/{}'.format(self.bucketlist_with_items_id, self.item_one_id),
+            data=json.dumps(updates),
+            headers=self.headers)
+        self.assertTrue(b'item updated successfully' in response.data)
+
         

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -52,7 +52,6 @@ class ItemResourceTest(BaseTest):
             '/api/v1/bucketlists/{}/items'.format(
                 self.bucketlist_with_items_id),
             headers=self.headers)
-        print(response.data)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(b'Item one' in response.data)
         self.assertTrue(b'Item two' in response.data)
@@ -63,6 +62,12 @@ class ItemResourceTest(BaseTest):
         response = self.client.get(
             '/api/v1/bucketlists/{}/items'.format(
                 self.bucketlist_with_items_id),
-            data=json.dumps(self.user),
             headers=no_token)
         self.assertTrue(b'Authorization Required' in response.data)
+
+    def test_response_message_for_non_existent_id(self):
+        response = self.client.get(
+            '/api/v1/bucketlists/2000/items', data={},
+            headers=self.headers)
+        print(response.data)
+        self.assertTrue(b'bucketlist does not exist' in response.data)

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -1,0 +1,51 @@
+from flask_sqlalchemy import SQLAlchemy
+import unittest
+import json
+from passlib.hash import bcrypt
+
+from app import app, db
+from app.models import User, Bucketlist, Item
+from base_testcase import BaseTest
+
+class ItemResourceTest(BaseTest):
+    def setUp(self):
+        super(ItemResourceTest, self).setUp()
+        self.user = {
+            "username": self.saved_user.username,
+            "password": "lion"
+        }
+
+        # create a bucketlist for tyrion
+        current_user = User.query.filter_by(
+            username=self.saved_user.username).first()
+        self.example_bucketlist_one = Bucketlist(
+            "bucketlist with items",
+            "this is bucketlist has itesm",
+            current_user.id)
+        db.session.add(self.example_bucketlist_one)
+        db.session.commit()
+
+        self.bucketlist_with_items_id = Bucketlist.query.filter_by(
+            name="bucketlist with items").first().id
+
+        self.item_1 = Item('Item one', 'this is ietm one', self.bucketlist_with_items_id)
+        self.item_2 = Item('Item two', 'this is ietm two', self.bucketlist_with_items_id)
+        db.session.flush()
+        db.session.commit()
+
+        self.response = self.client.post(
+            '/api/v1/auth/login', data=json.dumps(self.user),
+            headers=self.headers)
+        self.response_content = json.loads(self.response.data)
+        self.headers['Authorization'] = 'JWT {}'.format(
+            self.response_content['access_token'])
+
+
+    def test_item_names_returned_by_view_bucketlists(self):
+        response = self.client.get(
+            '/api/v1/bucketlists/{}/items'.format(self.bucketlist_with_items_id), 
+            data={},
+            headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(b'Item one' in response.data)
+        self.assertTrue(b'Item two' in response.data)

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -109,7 +109,7 @@ class ItemResourceTest(BaseTest):
             "description": "this is my first title"
         }
         response = self.client.post(
-            '/api/v1/bucketlists/{}/items'.format(self.item_one_id),
+            '/api/v1/bucketlists/{}/items'.format(self.bucketlist_with_items_id),
             data=json.dumps(new_item),
             headers=self.headers)
         print(response.data)
@@ -121,9 +121,22 @@ class ItemResourceTest(BaseTest):
             "description": "this is my first title"
         }
         response = self.client.post(
-            '/api/v1/bucketlists/{}/items'.format(self.item_one_id),
+            '/api/v1/bucketlists/{}/items'.format(self.bucketlist_with_items_id),
             data=json.dumps(new_item),
             headers=self.headers)
         print(response.data)
         self.assertTrue(b'empty strings not allowed' in response.data)
+
+    def test_cant_create_item_without_authentication(self):
+        new_item = {
+            "title": "new item title",
+            "description": "this is my first title"
+        }
+        no_token = self.headers
+        no_token['Authorization'] = ""
+        response = self.client.post(
+            '/api/v1/bucketlists/{}/items'.format(self.bucketlist_with_items_id),
+            data=json.dumps(new_item),
+            headers=no_token)
+        self.assertTrue(b'Authorization Required' in response.data)
         

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -51,6 +51,7 @@ class ItemResourceTest(BaseTest):
     def tearDown(self):
         super(ItemResourceTest, self).tearDown()
 
+    #view items
     def test_item_names_returned_by_view_bucketlists(self):
         response = self.client.get(
             '/api/v1/bucketlists/{}/items'.format(
@@ -76,6 +77,7 @@ class ItemResourceTest(BaseTest):
         print(response.data)
         self.assertTrue(b'bucketlist does not exist' in response.data)
 
+    #view item
     def test_item_name_returned_when_item_id_is_specified(self):
         response = self.client.get(
             '/api/v1/bucketlists/{}/items/{}'.format(
@@ -140,6 +142,8 @@ class ItemResourceTest(BaseTest):
             headers=no_token)
         self.assertTrue(b'Authorization Required' in response.data)
 
+
+    #update item
     def test_item_updated_successfully_message(self):
         updates = {
             "title": "not item one anymore",
@@ -160,6 +164,25 @@ class ItemResourceTest(BaseTest):
             data=json.dumps(updates),
             headers=self.headers)
         self.assertTrue(b'Missing required parameter' in response.data)
+
+    def test_message_on_update_with_empty_parameters(self):
+        updates = {
+            "title": "titular",
+            "description": ""
+        }
+        response = self.client.put(
+            '/api/v1/bucketlists/{}/items/{}'.format(self.bucketlist_with_items_id, self.item_one_id),
+            data=json.dumps(updates),
+            headers=self.headers)
+        self.assertTrue(b'empty strings not allowed' in response.data)
+
+    #delete item
+    def test_item_successfully_deleted(self):
+        response = self.client.delete(
+            '/api/v1/bucketlists/{}/items/{}'.format(
+                self.bucketlist_with_items_id, self.item_one_id),
+            headers=self.headers)
+        self.assertTrue(b'item deleted successfully' in response.data)
 
     
 

--- a/tests/test_user_resource.py
+++ b/tests/test_user_resource.py
@@ -55,7 +55,7 @@ class UserResourceTest(BaseTest):
             '/api/v1/auth/login', data=json.dumps(user),
             headers=self.headers)
         self.assertTrue(b'Invalid credentials' in response.data)
-
+    
     #user register tests
     def test_register_returns_ok_status_code(self):
         user = self.temp_user
@@ -97,3 +97,4 @@ class UserResourceTest(BaseTest):
             headers=self.headers)
         self.assertTrue(b'Make password should match '
                         b'confirm password' in response.data)
+    


### PR DESCRIPTION
#### What does this PR do?
Add view, create, update and delete features to the bucketlist API 
#### Description of Task to be completed?
Implement functionality for the endpoint:
- /api/v1/bucketlists/id/items
- /api/v1/bucketlists/id/items/item_id
For the get, post, put and delete requests
An authenticated user should be able to:
- Create a new item in their bucketlist by providing a title and description
- View existing items in a certain bucketlist identified by its id in the endpoint
- Update the title and description of a bucketlist
#### How should this be manually tested?
- The API endpoints can be tested using Postman or curl via the Terminal
- e.g for a get request on the /api/v1/bucketlists/id/items endpoint:
        - start the server locally by running; python run.py in the terminal
        - login with valid credentials to receive an authentication token
        - in a new tab set the request type to GET
        - enter the endpoint url in the Postman url field as: http://127.0.0.1:5000/api/v1/bucketlists/id/items
        - input the token received from login into the header with the key as Authorization. The token should be prefixed with "JWT "
        - click on the GET button to send the request
        - you should receive a response with all the items in the bucketlist or an empty response if there are no items in the bucketlist
#### What are the relevant pivotal tracker stories?
#149365789
#149365823
#149365803
#149861886
